### PR TITLE
Added priority and content_available fields to downstream XMPP message.

### DIFF
--- a/ccs/message.go
+++ b/ccs/message.go
@@ -11,7 +11,9 @@ type OutMsg struct {
 	Data                     map[string]string `json:"data,omitempty"`
 	MessageType              string            `json:"message_type,omitempty"`
 	CollapseKey              string            `json:"collapse_key,omitempty"`
-	TimeToLive               int               `json:"time_to_live,omitempty"`               //default:2419200 (in seconds = 4 weeks)
+	TimeToLive               int               `json:"time_to_live,omitempty"` //default:2419200 (in seconds = 4 weeks)
+	ContentAvailable         bool              `json:"content_available,omitempty"`
+	Priority                 string            `json:"priority,omitempty"`
 	DelayWhileIdle           bool              `json:"delay_while_idle,omitempty"`           //default:false
 	DeliveryReceiptRequested bool              `json:"delivery_receipt_requested,omitempty"` //default:false
 }


### PR DESCRIPTION
iOS devices need two GCM payload attributes to be able to process the message while the app is in the background :
- `priority`
- `content_available`

This PR adds those to the OutMsg struct.
